### PR TITLE
Update get_reaction_consistencies.R

### DIFF
--- a/R/get_reaction_consistencies.R
+++ b/R/get_reaction_consistencies.R
@@ -16,7 +16,8 @@ get_reaction_consistencies <- function(compass_reaction_scores, ..., min_consist
         compass_reaction_scores %>%
         drop_inconsistent_reactions(min_consistency = min_consistency) %>%
         drop_constant_reactions(min_range = min_range) %>%
-        (function(x) { -log2(x) })() %>%
-        sweep(2, colMeans(.))
+        (function(x) { -log2(1+x) })() %>%
+        #sweep(2, colMeans(.))
+        sweep(1, apply(.,1,min))
     reaction_consistencies
 }


### PR DESCRIPTION
As discussed last time, there is -log2(x) in the source code but not -log2(1+x), this may be necessary to change in case of 0 value.
Since each row represents a reaction while columns represent samples. From the source code, we can see in the scale step, each value minus the mean of the column may affect the difference between different sample groups and then affect the statistical test between different sample groups when we identify the differential reactions. Why not minus the minimum value of each row? Maybe this is your original intention.